### PR TITLE
Add support for l2domains when creating and maintaining vlans

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,6 @@ phpipam_vlan
     vlan: '100'
     name: 'required name'
     description: 'Optional description'
+    domainid: "1" # optional l2domain id, default: 1
     state: present
 ```

--- a/module_utils/phpipam.py
+++ b/module_utils/phpipam.py
@@ -44,11 +44,11 @@ class PhpIpamWrapper(urls.Request):
         except:
             return None
 
-    def get_vlan(self, vlan):
+    def get_vlan(self, vlan, domainid="1"):
         url = self.url + 'vlan/'
         vlan_response = json.load(self.get(url))
         for vlans in vlan_response['data']:
-            if vlans['number'] == vlan:
+            if vlans['number'] == vlan and vlans['domainId'] == domainid:
                 return vlans
         return None
 
@@ -72,8 +72,8 @@ class PhpIpamWrapper(urls.Request):
         except TypeError:
             return None
 
-    def get_vlan_id(self, vlan):
-        vlans = self.get_vlan(vlan)
+    def get_vlan_id(self, vlan, domainid=1):
+        vlans = self.get_vlan(vlan, domainid)
         try:
             if vlans['number'] == vlan:
                 return vlans['vlanId']

--- a/phpipam_freeip.py
+++ b/phpipam_freeip.py
@@ -115,7 +115,7 @@ output:
 
 
 from ansible.module_utils.basic import AnsibleModule
-import ansible.module_utils.phpipam as phpipam
+from ansible.module_utils.phpipam import PhpIpamWrapper
 import urllib
 import json
 
@@ -145,7 +145,7 @@ def main():
     hostname = module.params['hostname']
     description = module.params['description']
 
-    session = phpipam.PhpIpamWrapper(username, password, url)
+    session = PhpIpamWrapper(username, password, url)
     try:
         session.create_session()
     except AttributeError:

--- a/phpipam_section.py
+++ b/phpipam_section.py
@@ -121,8 +121,7 @@ output:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-import ansible.module_utils.phpipam as phpipam
-
+from ansible.module_utils.phpipam import PhpIpamWrapper
 
 def set_master_section(session, master_section):
     if master_section in ('', 'root'):
@@ -156,7 +155,7 @@ def main():
     description = module.params['description']
     state = module.params['state']
 
-    session = phpipam.PhpIpamWrapper(username, password, url)
+    session = PhpIpamWrapper(username, password, url)
     try:
         session.create_session()
     except AttributeError:

--- a/phpipam_subnet.py
+++ b/phpipam_subnet.py
@@ -129,7 +129,7 @@ output:
             sample: "206"
 '''
 from ansible.module_utils.basic import AnsibleModule
-import ansible.module_utils.phpipam as phpipam
+from ansible.module_utils.phpipam import PhpIpamWrapper
 
 
 def main():
@@ -161,7 +161,7 @@ def main():
     vlan = module.params['vlan']
     state = module.params['state']
 
-    session = phpipam.PhpIpamWrapper(username, password, url)
+    session = PhpIpamWrapper(username, password, url)
     try:
         session.create_session()
     except AttributeError:


### PR DESCRIPTION
Add support for L2Domains. domainid is now a phpipam_vlan module optional parameter which defaults to '1' if not set (the id of the default domain).

Default vlan descriptions to the string "None" when one isn't supplied in the module parameters (as this seems to be the behaviour of phpipam) to avoid vlans always appearing as 'changed' when no changes are required.
